### PR TITLE
Static GameInfo data can now be accessed from the GameState.

### DIFF
--- a/src/s2client-fsharp/Instance.fs
+++ b/src/s2client-fsharp/Instance.fs
@@ -175,6 +175,12 @@ module Instance =
 
         return playerId
     }
+    let getGameInfo (instance:Sc2Instance) = async {
+        // Do the join command
+        let! gameInfo, status = ProtbufConnection.getGameInfo instance.Connection
+        assert (status = Status.InGame)
+        return gameInfo }
+
     let getObservation disableFog (instance:Sc2Instance) = async {
         // Do the join command
         let! responseObs, status = ProtbufConnection.getObservation disableFog instance.Connection

--- a/src/s2client-fsharp/ProtobufConnection.fs
+++ b/src/s2client-fsharp/ProtobufConnection.fs
@@ -219,6 +219,14 @@ module ProtbufConnection =
         checkError joinGameResponse.Error joinGameResponse.ErrorDetails
         return joinGameResponse.PlayerId, response.Status }
 
+    let getGameInfo (cl : Sc2Connection) = async {
+        let request = new SC2APIProtocol.Request()
+        request.GameInfo <- new RequestGameInfo()
+        let! response = sendRequest cl request
+        let gameInfoResponse = response.GameInfo
+        checkNullAndWarnings response gameInfoResponse
+        return gameInfoResponse, response.Status }
+
     let getObservation disableFog (cl : Sc2Connection) = async {
         let request = new SC2APIProtocol.Request()
         request.Observation <- new RequestObservation()

--- a/src/s2client-fsharp/Sc2Game.fs
+++ b/src/s2client-fsharp/Sc2Game.fs
@@ -9,12 +9,14 @@ type GameState =
     NewObservation : SC2APIProtocol.ResponseObservation
     // more global state
     PlayerId : PlayerId
+    GameInfo : SC2APIProtocol.ResponseGameInfo
      }
     static member Empty playerId = 
       { LastObservation = None
         LastActions = []
         NewObservation = null
-        PlayerId = playerId }
+        PlayerId = playerId
+        GameInfo = null }
 
 type Sc2Bot = GameState -> SC2APIProtocol.Action list
 type Sc2Observer = GameState -> unit
@@ -141,6 +143,12 @@ module Sc2Game =
                 | Computer _, _ -> None
                 | _ -> failwithf "Expected playerId when participant or observer but not when computer. %A" (part,playerId)
             )
+
+        // Get the static gameInfo
+        for (playerId, instance, bot) in relevantPlayers do
+            let! gameInfo = Instance.getGameInfo instance
+            let state = getState playerId
+            updateState playerId { state with GameInfo = gameInfo }
 
         // Game loop
         while true do


### PR DESCRIPTION
With these changes, the static GameInfo will be loaded in the runGame function.
The information will be made available to the bot from the GameState object.

This should be a fix for this issue: https://github.com/matthid/s2client-dotnet/issues/4
If there are any questions or suggestions for improvements, please leave a message!